### PR TITLE
util.isArray doesn't exist in node < v0.6

### DIFF
--- a/lib/buildy/queue.js
+++ b/lib/buildy/queue.js
@@ -6,7 +6,13 @@ var util        = require('util')
     , events    = require('events')
     , winston   = require('winston')
     , Registry  = require('./registry')
-    , State     = require('./state');
+    , State     = require('./state')
+    , isArray = util.isArray || function(ar) {
+        return Array.isArray(ar) ||
+            (typeof ar === 'object' && objectToString(ar) === '[object Array]');
+    };
+
+
 
 /**
  *
@@ -111,7 +117,7 @@ var Queue = module.exports = function Queue(name, options) {
      * @default []
      * @private
      */
-    this._skip = util.isArray(options.skip) ? options.skip : [];
+    this._skip = isArray(options.skip) ? options.skip : [];
 
     /**
      * Task default parameters.


### PR DESCRIPTION
At Yahoo we use v0.4.13 which doesn't have util.isArray:
https://github.com/joyent/node/wiki/API-changes-between-v0.4-and-v0.6

I added a check for util.isArray, if it doesn't exist we define it. I use the same isArray from node source:
https://github.com/joyent/node/blob/master/lib/util.js#L380
